### PR TITLE
ow2-proactive/scheduling#2411 : add a binding which contains command exit code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
-version = '0.3'
+version = '0.4'
 group = 'jsr223'
 
 sourceCompatibility = 1.7
@@ -9,10 +9,25 @@ sourceCompatibility = 1.7
 defaultTasks 'jar'
 
 repositories {
-    mavenCentral()
+    jcenter()
 }
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'commons-io', name: 'commons-io', version: '1.4'
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            snapshotRepository(url: "http://repository.activeeon.com/content/repositories/snapshots/") {
+                authentication(userName: "${System.getProperty('nexusUsername')}",
+                        password: "${System.getProperty('nexusPassword')}")
+            }
+            repository(url: "http://repository.activeeon.com/content/repositories/releases/") {
+                authentication(userName: "${System.getProperty('nexusUsername')}",
+                        password: "${System.getProperty('nexusPassword')}")
+            }
+        }
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Sat Jan 04 17:19:34 CET 2014
+#Wed Feb 10 17:09:22 CET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/jsr223/nativeshell/executable/ExecutableScriptEngine.java
+++ b/src/main/java/jsr223/nativeshell/executable/ExecutableScriptEngine.java
@@ -11,6 +11,10 @@ import static jsr223.nativeshell.StringUtils.toEmptyStringIfNull;
 
 public class ExecutableScriptEngine extends AbstractScriptEngine {
 
+    public static final String EXIT_VALUE_BINDING_NAME = "EXIT_VALUE";
+
+    public static final String VARIABLES__BINDING_NAME = "variables";
+
     @Override
     public Object eval(String script, ScriptContext scriptContext) throws ScriptException {
         try {
@@ -38,9 +42,16 @@ public class ExecutableScriptEngine extends AbstractScriptEngine {
             input.interrupt();
 
             int exitValue = process.exitValue();
+
+            if (scriptContext.getBindings(ScriptContext.ENGINE_SCOPE).containsKey(VARIABLES__BINDING_NAME)) {
+                Map<String, Serializable> variables = (Map<String, Serializable>) scriptContext.getBindings(ScriptContext.ENGINE_SCOPE).get(VARIABLES__BINDING_NAME);
+                variables.put(EXIT_VALUE_BINDING_NAME, exitValue);
+            }
+            scriptContext.getBindings(ScriptContext.ENGINE_SCOPE).put(EXIT_VALUE_BINDING_NAME, exitValue);
             if (exitValue != 0) {
                 throw new ScriptException("Command execution failed with exit code " + exitValue);
             }
+
             return exitValue;
         } catch (ScriptException e) {
             throw e;

--- a/src/test/java/jsr223/nativeshell/executable/ExecutableScriptEngineTest.java
+++ b/src/test/java/jsr223/nativeshell/executable/ExecutableScriptEngineTest.java
@@ -1,20 +1,19 @@
 package jsr223.nativeshell.executable;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.io.StringWriter;
-
-import javax.script.Bindings;
-import javax.script.ScriptException;
-
 import jsr223.nativeshell.NativeShellRunner;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.script.Bindings;
+import javax.script.ScriptException;
+import java.io.*;
+import java.util.HashMap;
+
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ExecutableScriptEngineTest {
 
@@ -87,6 +86,38 @@ public class ExecutableScriptEngineTest {
         scriptEngine.eval("echo $var", bindings);
 
         assertEquals("\n", scriptOutput.toString());
+    }
+
+    @Test
+    public void exitCodeBindingSuccess() throws Exception {
+        Bindings bindings = scriptEngine.createBindings();
+
+        HashMap<String, Serializable> variables = new HashMap<>();
+        bindings.put(ExecutableScriptEngine.VARIABLES__BINDING_NAME, variables);
+
+        scriptEngine.eval("echo ok", bindings);
+
+        assertEquals(bindings.get(ExecutableScriptEngine.EXIT_VALUE_BINDING_NAME), 0);
+        assertEquals(variables.get(ExecutableScriptEngine.EXIT_VALUE_BINDING_NAME), 0);
+    }
+
+    @Test
+    public void exitCodeBindingError() throws Exception {
+        Bindings bindings = scriptEngine.createBindings();
+
+        HashMap<String, Serializable> variables = new HashMap<>();
+        bindings.put(ExecutableScriptEngine.VARIABLES__BINDING_NAME, variables);
+
+        boolean exceptionThrown = false;
+        try {
+            scriptEngine.eval("pprijbjhbqjhrj", bindings);
+
+        } catch (Exception e) {
+            exceptionThrown = true;
+        }
+        assertTrue(exceptionThrown);
+        assertNotEquals(bindings.get(ExecutableScriptEngine.EXIT_VALUE_BINDING_NAME), 0);
+        assertNotEquals(variables.get(ExecutableScriptEngine.EXIT_VALUE_BINDING_NAME), 0);
     }
 
     @Test

--- a/src/test/java/jsr223/nativeshell/executable/ExecutableScriptEngineTest.java
+++ b/src/test/java/jsr223/nativeshell/executable/ExecutableScriptEngineTest.java
@@ -2,6 +2,7 @@ package jsr223.nativeshell.executable;
 
 import jsr223.nativeshell.NativeShellRunner;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.script.Bindings;
@@ -20,6 +21,12 @@ public class ExecutableScriptEngineTest {
     private ExecutableScriptEngine scriptEngine;
     private StringWriter scriptOutput;
     private StringWriter scriptError;
+
+    @BeforeClass
+    public static void notOnWindows() {
+        org.junit.Assume.assumeFalse(System.getProperty("os.name").toLowerCase().contains("windows"));
+        // rest of setup.
+    }
 
     @Before
     public void setup() {


### PR DESCRIPTION
ow2-proactive/scheduling#2411

At the end of the execution, the exit code is stored in a binding called EXIT_VALUE. And if the bindings already contain a "variables" map, add this value to it.
