### PR TITLE
destroyProcessGracefullyAfterFirstInterrupt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
-version = '0.4.1'
+version = '0.4.2'
 group = 'jsr223'
 
 sourceCompatibility = 1.7


### PR DESCRIPTION
Destroy process gracefully after first interrupt

Problem:
- Interrupt Exception (killing a task) jumps immediately out of the script engine code
- Process which was started is forcefully killed without able to cleanup or save progress
- Process is killed with garbage colletion

Solution:
- Catch InterruptedException and call Process.destroy()
- Process.destroy() will send a SIGTERM to the Linux process (http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/solaris/native/java/lang/UNIXProcess_md.c#l720) and calls the TerminateProcess method of the Windows process (http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/windows/native/java/lang/ProcessImpl_md.c#l435)
