### PR TITLE
Bash script engine terminates immediately in run as me forked mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
-version = '0.4.2'
+version = '0.4.3'
 group = 'jsr223'
 
 sourceCompatibility = 1.7


### PR DESCRIPTION
Bash script engine terminates immediately in run as me forked mode

Problem:
- The bash script engine terminates immediately in run as me forked mode

Solution
- Add a shutdown hook which stops the immediate termination an waits for another interrupt