### PR TITLE
Disable version check by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.4.4
+version=0.4.5
 groupId=jsr223
 artifactId=jsr223-nativeshell

--- a/src/main/java/jsr223/nativeshell/NativeShellRunner.java
+++ b/src/main/java/jsr223/nativeshell/NativeShellRunner.java
@@ -30,19 +30,39 @@ public class NativeShellRunner {
         this.nativeShell = nativeShell;
     }
 
+    private boolean isVersionCheckEnabled() {
+        String versionCheckProperty = System.getProperty(NativeShellScriptEngine.ENABLE_VERSION_PROPERTY_NAME);
+        if (versionCheckProperty != null) {
+            try {
+                return Boolean.parseBoolean(versionCheckProperty);
+            } catch (Exception e) {
+                return false;
+            }
+        }
+        return false;
+    }
+
     public String getInstalledVersion() {
-        try {
-            return runAndGetOutput(nativeShell.getInstalledVersionCommand());
-        } catch (Throwable e) {
-            return "Could not determine version";
+        if (isVersionCheckEnabled()) {
+            try {
+                return runAndGetOutput(nativeShell.getInstalledVersionCommand());
+            } catch (Throwable e) {
+                return "Could not determine version";
+            }
+        } else {
+            return NativeShellScriptEngine.DEFAULT_VERSION;
         }
     }
 
     public String getMajorVersion() {
-        try {
-            return runAndGetOutput(nativeShell.getMajorVersionCommand());
-        } catch (Throwable e) {
-            return "Could not determine version";
+        if (isVersionCheckEnabled()) {
+            try {
+                return runAndGetOutput(nativeShell.getMajorVersionCommand());
+            } catch (Throwable e) {
+                return "Could not determine version";
+            }
+        } else {
+            return NativeShellScriptEngine.DEFAULT_MAJOR_VERSION;
         }
     }
 

--- a/src/main/java/jsr223/nativeshell/NativeShellScriptEngine.java
+++ b/src/main/java/jsr223/nativeshell/NativeShellScriptEngine.java
@@ -7,6 +7,12 @@ import java.util.Map;
 
 public class NativeShellScriptEngine extends AbstractScriptEngine {
 
+    public static final String ENABLE_VERSION_PROPERTY_NAME = "jsr223.nativeshell.enableVersionCheck";
+
+    public static final String DEFAULT_VERSION = "1.0.0";
+
+    public static final String DEFAULT_MAJOR_VERSION = "1";
+
     public static final String EXIT_VALUE_BINDING_NAME = "EXIT_VALUE";
 
     public static final String VARIABLES_BINDING_NAME = "variables";


### PR DESCRIPTION
Version check can create a hanging bash.exe process on windows machine if a bash.exe is found in the windows system PATH.