### PR TITLE
Fix the bug of passing arguments when restart PA server

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.6.1
+version=0.6.2
 groupId=jsr223
 artifactId=jsr223-nativeshell

--- a/src/main/java/jsr223/nativeshell/NativeShellRunner.java
+++ b/src/main/java/jsr223/nativeshell/NativeShellRunner.java
@@ -37,6 +37,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
+import java.io.Serializable;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
@@ -130,11 +131,14 @@ public class NativeShellRunner {
     private List<String> getArguments(ScriptContext scriptContext) {
         Bindings bindings = scriptContext.getBindings(ScriptContext.ENGINE_SCOPE);
         if (bindings != null && bindings.containsKey(Script.ARGUMENTS_NAME)) {
-            if (bindings.get(Script.ARGUMENTS_NAME) instanceof String[]) {
-                String[] arguments = (String[]) bindings.get(Script.ARGUMENTS_NAME);
+            Object argumentsObject = bindings.get(Script.ARGUMENTS_NAME);
+            if (argumentsObject instanceof String[]) {
+                String[] arguments = (String[]) argumentsObject;
                 return Arrays.asList(arguments);
-            } else {
-                // should never occur, unfortunately, we cannot log this issue
+            } else if (argumentsObject instanceof Serializable[]) {
+                Serializable[] argumentsSerializable = (Serializable[]) argumentsObject;
+                String[] arguments = Arrays.copyOf(argumentsSerializable, argumentsSerializable.length, String[].class);
+                return Arrays.asList(arguments);
             }
         }
         return new ArrayList<>();


### PR DESCRIPTION
Fix the bug of passing task implementation arguments when the job is executed after ProActive Scheduler server is restarted.

The bug is caused by the fact that when job is loaded from DB after PA server is restarted, `Script.parameters` has the type Serializable[] instead of `String[]`.